### PR TITLE
Use spawn and validate inputs for stateful action

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,34 +15,66 @@ then
 fi
 
 
-if git fetch origin $INPUT_BRANCH
+if git fetch origin "$INPUT_BRANCH"
 then
   # $INPUT_BRANCH branch already exists
-  git worktree add -b $INPUT_BRANCH ./.$INPUT_BRANCH origin/$INPUT_BRANCH
+  git worktree add -b "$INPUT_BRANCH" "./.$INPUT_BRANCH" "origin/$INPUT_BRANCH"
 else
   # $INPUT_BRANCH branch doesn't exist yet
   echo "Creating $INPUT_BRANCH branch..."
-  git worktree add --detach .$INPUT_BRANCH/
-  cd .$INPUT_BRANCH/
-  git checkout --orphan $INPUT_BRANCH
+  git worktree add --detach "./.$INPUT_BRANCH/"
+  cd "./.$INPUT_BRANCH/"
+  git checkout --orphan "$INPUT_BRANCH"
   git reset --hard
   cd ..
 fi
 `;
-const exec = require('child_process').exec;
+const { spawn } = require('child_process');
 
-process.env.INPUT_BRANCH = process.env.INPUT_BRANCH || 'state';
-process.env.INPUT_BACKUP = process.env.INPUT_BACKUP || '100';
+const branch = process.env.INPUT_BRANCH || 'state';
+const backup = process.env.INPUT_BACKUP || '100';
+const authorEmail = process.env.INPUT_GIT_AUTHOR_EMAIL || '';
+const authorName = process.env.INPUT_GIT_AUTHOR_NAME || '';
 
-const run = exec(`bash -e <<'EOF'\n${script}\nEOF`, (error, stdout, stderr) => {
-    if (error) {
-        console.error(`exec error: ${error}`);
-        process.exit(error.code);
-    }
-});
+if (!/^[A-Za-z0-9-]+$/.test(branch)) {
+  console.error('Invalid INPUT_BRANCH');
+  process.exit(1);
+}
+if (!/^[0-9]+$/.test(backup)) {
+  console.error('Invalid INPUT_BACKUP');
+  process.exit(1);
+}
+if (authorEmail && !/^[A-Za-z0-9@._+-]+$/.test(authorEmail)) {
+  console.error('Invalid INPUT_GIT_AUTHOR_EMAIL');
+  process.exit(1);
+}
+if (authorName && !/^[A-Za-z0-9 _.-]+$/.test(authorName)) {
+  console.error('Invalid INPUT_GIT_AUTHOR_NAME');
+  process.exit(1);
+}
+
+process.env.INPUT_BRANCH = branch;
+process.env.INPUT_BACKUP = backup;
+process.env.INPUT_GIT_AUTHOR_EMAIL = authorEmail;
+process.env.INPUT_GIT_AUTHOR_NAME = authorName;
+
+const run = spawn('bash', ['-e'], { env: process.env });
+
+run.stdin.write(script);
+run.stdin.end();
+
 run.stdout.on('data', (data) => {
-    console.log(data);
+  process.stdout.write(data);
 });
 run.stderr.on('data', (data) => {
-    console.error(data);
+  process.stderr.write(data);
+});
+run.on('close', (code) => {
+  if (code !== 0) {
+    process.exit(code);
+  }
+});
+run.on('error', (error) => {
+  console.error(`spawn error: ${error}`);
+  process.exit(1);
 });

--- a/post.js
+++ b/post.js
@@ -2,7 +2,7 @@ const script = `
 #/bin/bash -e
 # Commit changes on $INPUT_BRANCH branch and squash old commits
 
-cd .$INPUT_BRANCH/
+cd "./.$INPUT_BRANCH/"
 
 git add .
 
@@ -11,38 +11,70 @@ then
   echo "$INPUT_BRANCH didn't change"
 else
   # Push new commit
-  git push origin $INPUT_BRANCH
+  git push origin "$INPUT_BRANCH"
 
   # Squash all the commits except last $INPUT_BACKUP
-  export N=$(($(git rev-list --count $INPUT_BRANCH --) - $INPUT_BACKUP))
+  export N=$(($(git rev-list --count "$INPUT_BRANCH" --) - $INPUT_BACKUP))
   if (( $N > 0 ))
   then
     echo "Squashing $N commits"
-    EDITOR="sed -i '1,100 ! s/^pick/fixup/'" git rebase -i --root $INPUT_BRANCH --keep-empty
-    git push -f origin $INPUT_BRANCH
+    EDITOR="sed -i '1,100 ! s/^pick/fixup/'" git rebase -i --root "$INPUT_BRANCH" --keep-empty
+    git push -f origin "$INPUT_BRANCH"
   fi
 fi
 
 # Cleanup
 cd ..
-git worktree remove .$INPUT_BRANCH
-git branch -D $INPUT_BRANCH
+git worktree remove "./.$INPUT_BRANCH"
+git branch -D "$INPUT_BRANCH"
 
 `;
-const exec = require('child_process').exec;
+const { spawn } = require('child_process');
 
-process.env.INPUT_BRANCH = process.env.INPUT_BRANCH || 'state';
-process.env.INPUT_BACKUP = process.env.INPUT_BACKUP || '100';
+const branch = process.env.INPUT_BRANCH || 'state';
+const backup = process.env.INPUT_BACKUP || '100';
+const authorEmail = process.env.INPUT_GIT_AUTHOR_EMAIL || '';
+const authorName = process.env.INPUT_GIT_AUTHOR_NAME || '';
 
-const run = exec(`bash -e <<'EOF'\n${script}\nEOF`, (error, stdout, stderr) => {
-    if (error) {
-        console.error(`exec error: ${error}`);
-        process.exit(error.code);
-    }
-});
+if (!/^[A-Za-z0-9-]+$/.test(branch)) {
+  console.error('Invalid INPUT_BRANCH');
+  process.exit(1);
+}
+if (!/^[0-9]+$/.test(backup)) {
+  console.error('Invalid INPUT_BACKUP');
+  process.exit(1);
+}
+if (authorEmail && !/^[A-Za-z0-9@._+-]+$/.test(authorEmail)) {
+  console.error('Invalid INPUT_GIT_AUTHOR_EMAIL');
+  process.exit(1);
+}
+if (authorName && !/^[A-Za-z0-9 _.-]+$/.test(authorName)) {
+  console.error('Invalid INPUT_GIT_AUTHOR_NAME');
+  process.exit(1);
+}
+
+process.env.INPUT_BRANCH = branch;
+process.env.INPUT_BACKUP = backup;
+process.env.INPUT_GIT_AUTHOR_EMAIL = authorEmail;
+process.env.INPUT_GIT_AUTHOR_NAME = authorName;
+
+const run = spawn('bash', ['-e'], { env: process.env });
+
+run.stdin.write(script);
+run.stdin.end();
+
 run.stdout.on('data', (data) => {
-    console.log(data);
+  process.stdout.write(data);
 });
 run.stderr.on('data', (data) => {
-    console.error(data);
+  process.stderr.write(data);
+});
+run.on('close', (code) => {
+  if (code !== 0) {
+    process.exit(code);
+  }
+});
+run.on('error', (error) => {
+  console.error(`spawn error: ${error}`);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- replace `exec` with `spawn` to run bash scripts without shell interpolation
- validate branch, backup, and author inputs to allow only safe characters
- quote branch references inside bash scripts

## Testing
- `node --check main.js`
- `node --check post.js`


------
https://chatgpt.com/codex/tasks/task_b_68b655ff2ddc8325b904a345684760ac