### PR TITLE
feat: validate gitignore before grepping

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,6 +8,12 @@ then
   git config user.name "$INPUT_GIT_AUTHOR_NAME"
 fi
 
+if ! test -f .gitignore
+then
+  echo "Missing .gitignore file. Please create one and include .$INPUT_BRANCH/ in it"
+  exit 1
+fi
+
 if ! grep -Fxq ".$INPUT_BRANCH/" .gitignore
 then
   echo "Please make sure .$INPUT_BRANCH/ is present in .gitignore"

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -7,6 +7,12 @@ then
   git config user.name "$INPUT_GIT_AUTHOR_NAME"
 fi
 
+if ! test -f .gitignore
+then
+  echo "Missing .gitignore file. Please create one and include .$INPUT_BRANCH/ in it"
+  exit 1
+fi
+
 if ! grep -Fxq ".$INPUT_BRANCH/" .gitignore
 then
   echo "Please make sure .$INPUT_BRANCH/ is present in .gitignore"


### PR DESCRIPTION
## Summary
- ensure `.gitignore` exists before validating branch entry
- exit with clear guidance when `.gitignore` is missing

## Testing
- `mv .gitignore .gitignore.bak && node main.js; mv .gitignore.bak .gitignore`
- `node main.js`
- `node post.js` *(fails: branch 'state' not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b65701a98883258e0dd26906237afd